### PR TITLE
Cache the past statistics of wiki

### DIFF
--- a/.github/workflows/rank.yml
+++ b/.github/workflows/rank.yml
@@ -30,7 +30,10 @@ jobs:
     - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: tmp/rc-cache
-        key: rc-cache
+        # 키가 고정되어 있으면 최초 저장 이후 캐시가 갱신되지 않으므로 실행마다 새 키로 저장한다
+        key: rc-cache-${{ github.run_id }}
+        restore-keys: |
+          rc-cache-
 
     - name: Install uv
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
@@ -46,13 +49,10 @@ jobs:
         # 보존할 바뀐글 캐시 일수. 30일까지 계산할 것이므로 30개만 있으면 되는데 혹시 모르니 여유를 둬서 35개 유지
         TIME_WINDOW: 35
       run: |
-        OLDS=$(ls -t tmp/rc-cache | tail -n +${{ env.TIME_WINDOW }})
         echo 'Old files:'
-        echo $OLDS
+        ls -t tmp/rc-cache | tail -n "+$((TIME_WINDOW + 1))"
 
-        IFS=$'\n\t'
-        for OLD in "$OLDS"; do
-          [ -f "tmp/rc-cache/$OLD" ] && rm "tmp/rc-cache/$OLD"
-        done
+        ls -t tmp/rc-cache | tail -n "+$((TIME_WINDOW + 1))" | xargs -r -I{} rm -- 'tmp/rc-cache/{}'
+
         echo 'Cached files:'
         ls tmp/rc-cache


### PR DESCRIPTION
Fixes #136

`actions/cache`는 키가 정확히 일치하는 캐시가 이미 있으면 저장을 건너뛰기 때문에, 고정 키 `rc-cache`로는 최초 한 번 저장된 캐시가 영영 갱신되지 않았습니다. 그래서 옛 날짜 파일이 계속 남고 새 파일은 저장되지 않았습니다 (#136).

- 캐시 키를 `rc-cache-${{ github.run_id }}`로 바꾸고 `restore-keys: rc-cache-` 접두사로 최신 캐시를 복원하도록 하여 매 실행마다 새 캐시가 저장되게 함
- 오래된 캐시 파일 삭제 루프가 실제로는 전체 문자열을 한 번에 순회해서 동작하지 않던 것을 xargs 파이프라인으로 교체
- `tail -n +35`가 34개만 남기던 off-by-one을 수정하여 정확히 TIME_WINDOW(35)개 유지

기존 `rc-cache` 키의 캐시는 새 접두사와 일치하지 않아 복원되지 않지만, 어차피 오래되어 쓸모없는 데이터라 첫 실행에서 새로 채워지는 편이 낫습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)